### PR TITLE
Fixed spam issue & timer function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dean/
 /venv/
 
 *.pickle
+.google-cookie
+test-time.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ dean/
 
 *.pickle
 .google-cookie
-test-time.txt

--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -54,7 +54,8 @@ def receive_message():
 
         return verify_fb_token(token_sent)
     
-    #if the request was not get, it must be POST and we can just proceed with sending a message back to user
+    # if the request was not get, it must be POST and we can just proceed with sending a message back to user
+    # Bryan: do we really need to load df.pickle every after message?
     if os.path.exists('df.pickle'):
         with open('df.pickle', 'rb') as x:
             df = pickle.load(x)
@@ -85,11 +86,11 @@ def receive_message():
                 #Stops message spam
                 with open('message.pickle', 'rb') as x:
                     previous_message = pickle.load(x)
-                    check_message = previous_message
+                    check_message = previous_message  # Bryan: This copies the whole data from pickle. could be more space-efficient?
 
                 #Store recipient ID in previous message
                 if check_message.get(recipient_id):
-                    pass
+                    pass            # Bryan: this could be cleaner. pass is unnecessary
                 else:
                     initial_message[recipient_id] = {}
                     previous_message = initial_message
@@ -141,7 +142,6 @@ def receive_message():
         #if user sends us a GIF, photo,video, or any other non-text item
         if message['message'].get('attachments'):
             #process_media(message['message'].get('attachments'))
-            send_message(recipient_id, "I can only process text messages. I apologize for the inconvenience.")
             pass
             return "Messaged Processed"
     #If user clicked one of the postback buttons
@@ -254,4 +254,8 @@ def feedback(recipient_id):
                     ]
         button_message(recipient_id,message,buttons)
     return "success"
+
+def searchbot():
+    '''Search from Google based on recipient's message. Created for cleaner code and to record search time.'''
+
 

--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -29,18 +29,12 @@ def timer(func):
         value = func(*args,**kwargs)
         end_time = time.perf_counter()
         run_time = end_time - start_time
-        # print(f"Finished {func.__name__!r} in {run_time:.4f} secs")
-        # save time to test-time.txt
-        with open("test-time.txt", mode='a') as f:
-            print(f"Finished {func.__name__!r} in {run_time:.4f} secs", file=f)
-            print(len(df))
-
+        print(f"Finished {func.__name__!r} in {run_time:.4f} secs")
         return value
     return wrapper_timer
 
 #We will receive messages that Facebook sends our bot at this endpoint 
 @app.route("/", methods=['GET', 'POST'])
-@timer
 def receive_message():
     #remember list of articles and what are article the user is reading
     global df
@@ -53,171 +47,169 @@ def receive_message():
         token_sent = request.args.get("hub.verify_token")
 
         return verify_fb_token(token_sent)
-    
-    # if the request was not get, it must be POST and we can just proceed with sending a message back to user
-    # Bryan: do we really need to load df.pickle every after message?
-    if os.path.exists('df.pickle'):
-        with open('df.pickle', 'rb') as x:
-            df = pickle.load(x)
-
-    with open('message.pickle', 'wb') as x:
-        pickle.dump(message_dict, x, protocol=pickle.HIGHEST_PROTOCOL)
-
-    # Get POST request sent to the bot
-    output = request.get_json()
-    print(output)
-
-    # Get message details
-    message = output['entry'][0]['messaging'][0]
-
-    #Facebook Messenger ID for user so we know where to send response back to
-    recipient_id = str(message['sender']['id'])
-    message_dict[recipient_id] = message
-
-    #If user sent a message
-    if message.get('message'):
-        if message['message'].get('text'):
-            text = message['message'].get('text').strip()
-            string = text.lstrip().split(' ',1)
-            
-            #If the person wants to search something
-            if string[0].lower() == 'search' and len(string) >= 2:
-
-                #Stops message spam
-                with open('message.pickle', 'rb') as x:
-                    previous_message = pickle.load(x)
-                    check_message = previous_message  # Bryan: This copies the whole data from pickle. could be more space-efficient?
-
-                #Store recipient ID in previous message
-                if check_message.get(recipient_id):
-                    pass
-                else:
-                    initial_message[recipient_id] = {}
-                    previous_message = initial_message
-
-                print('previous message: ', previous_message[recipient_id])
-                print('message: ', message)
-                if message == previous_message[recipient_id]:
-                    print('STOP FUNCTION BEFORE IT SPAMS')
-                    return 'message processed'
-                else: 
-                    send_message(recipient_id,"Thank you for your search! Let me see what I can find. :)")
-                    articles = push(links(string[1]))
-                    if articles:
-                        df.pop(recipient_id, None)
-                        with open('df.pickle', 'wb') as x:
-                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                        articles.insert(0,1)
-                        df[recipient_id] = articles
-                        with open('df.pickle', 'wb') as z:
-                            pickle.dump(df, z, protocol = pickle.HIGHEST_PROTOCOL)
-                        #feedback(recipient_id)
-                        for i in range(1,len(articles)):
-                            #Send a button allowing them to read more of the article
-                            buttons = [
-                                            {
-                                                "type":"postback",
-                                                "title":"Read",
-                                                "payload": i
-                                            }
-                                        ]
-                            #Send the title and summary of the article
-                            button_message(recipient_id,articles[i]['title'][0:350],buttons)
-                        
-                    else:
-                        send_message(recipient_id,'''I couldn't find anything on that, could you try making your search more specific? It would help if you asked a question! (Ex. "Who is the President of the Philippines?)''')
-                return "Messaged Processed"
-            #If the person mistakenly just said search
-            elif string[0].lower() == 'search' and len(string) == 1:
-                send_message(recipient_id, "Hi there! Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
-                #TELL THEM THAT 
-            #All other cases 
-            else:
-                answer = process_message(text)
-                if answer:
-                    send_message(recipient_id,answer)
-                else:
-                    send_message(recipient_id,"Can you say that again? Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
-            return "Messaged Processed"
-        #if user sends us a GIF, photo,video, or any other non-text item
-        if message['message'].get('attachments'):
-            #process_media(message['message'].get('attachments'))
-            pass
-            return "Messaged Processed"
-    #If user clicked one of the postback buttons
-    elif message.get('postback'):
-        print('DF Keys Existing: ',df.keys())
-        if message['postback'].get('title'):
-            #If user clicks the get started button
-            if message['postback']['title'] == 'Get Started':
-                send_message(recipient_id, "Hey, I'm Dean! I allow Filipinos to access Google Search at no cost. This app runs purely on Free Facebook Data.\n\nIf you want to get started, just ask me a question! Make sure you write 'search' before your query. I'm excited to learn with you!\n\nI hope that you continue to stay safe! :)")
-            
-            #If user wants to read a specific article
-            #update df with new choice
-            elif df.get(recipient_id):
-                #retrieve choice from postback
-                choice = int(message['postback']['payload'])
-                df[recipient_id][0] = choice
-                if message['postback']['title'] == 'Read':
-                    print('DF Keys Read: ',df.keys())
-                    #dictionary for buttons
-                    buttons = [
-                                    {
-                                        "type":"postback",
-                                        "title":"Read more",
-                                        "payload":choice
-                                    }
-                                ]
-                    #send button message
-                    if len(df[recipient_id][choice]['article']) == 1:
-                        send_message(recipient_id,df[recipient_id][choice]['article'][0])
-                        df[recipient_id][choice]['article'] = "End"
-                        with open('df.pickle', 'wb') as x:
-                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                        send_message(recipient_id,"End of Article")
-                    elif df[recipient_id][choice]['article'] == "End":
-                        send_message(recipient_id,"End of Article")
-                    else:
-                        button_message(recipient_id,df[recipient_id][choice]['article'][0],buttons)
-                        df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
-                        with open('df.pickle', 'wb') as x:
-                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                    return "Messaged Processed"
-                #If user wants to read more of the article
-                elif message['postback']['title'] == 'Read more':
-                    buttons = [
-                                    {
-                                        "type":"postback",
-                                        "title":"Read more",
-                                        "payload":choice
-                                    }
-                                ]
-                    print('Read More Keys: ',df.keys())
-                    if len(df[recipient_id][choice]['article']) == 1:
-                        send_message(recipient_id, df[recipient_id][choice]['article'][0])
-                        df[recipient_id][choice]['article'] = "End"
-                        with open('df.pickle', 'wb') as x:
-                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                        send_message(recipient_id, "End of Article")
-                    elif df[recipient_id][choice]['article'] == "End":
-                        send_message(recipient_id, "End of Article")
-                    else:
-                        button_message(recipient_id, df[recipient_id][choice]['article'][0], buttons)
-                        df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
-                        with open('df.pickle', 'wb') as x:
-                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                    return "Messaged Processed"
-                elif message['postback']['title'] == 'Feedback':
-                    pass
-            else:
-                send_message(recipient_id, "Hi there! Could you please repeat your search? Make sure you write 'search' before your query. Ex. search Who is the President of the Philippines")
-            return "Messaged Processed"
+    #if the request was not get, it must be POST and we can just proceed with sending a message back to user
     else:
-        #gets triggered if there is another type of message that's not message/postback
-        pass
+        if os.path.exists('df.pickle'):
+            with open('df.pickle', 'rb') as x:
+                df = pickle.load(x)
+
+        with open('message.pickle', 'wb') as x:
+            pickle.dump(message_dict, x, protocol=pickle.HIGHEST_PROTOCOL)
+
+        # Get POST request sent to the bot
+        output = request.get_json()
+        print(output)
+
+        # Get message details
+        message = output['entry'][0]['messaging'][0]
+
+        #Facebook Messenger ID for user so we know where to send response back to
+        recipient_id = str(message['sender']['id'])
+        message_dict[recipient_id] = message
+
+        #If user sent a message
+        if message.get('message'):
+            if message['message'].get('text'):
+                text = message['message'].get('text').strip()
+                string = text.lstrip().split(' ',1)
+                
+                #If the person wants to search something
+                if string[0].lower() == 'search' and len(string) >= 2:
+
+                    #Stops message spam
+                    with open('message.pickle', 'rb') as x:
+                        previous_message = pickle.load(x)
+                        check_message = previous_message
+
+                    #Store recipient ID in previous message
+                    if check_message.get(recipient_id):
+                        pass
+                    else:
+                        initial_message[recipient_id] = {}
+                        previous_message = initial_message
+
+                    print('previous message: ', previous_message[recipient_id])
+                    print('message: ', message)
+                    if text == previous_message[recipient_id]['message'].get('text').strip():
+                        send_message(recipient_id, "You've repeated your previous message. DEAN hates spam!")
+                        return 'message processed'
+                    else:
+                        send_message(recipient_id,"Thank you for your search! Let me see what I can find. :)")
+                        articles = push(links(string[1]))
+                        if articles:
+                            df.pop(recipient_id, None)
+                            with open('df.pickle', 'wb') as x:
+                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                            articles.insert(0,1)
+                            df[recipient_id] = articles
+                            with open('df.pickle', 'wb') as z:
+                                pickle.dump(df, z, protocol = pickle.HIGHEST_PROTOCOL)
+                            #feedback(recipient_id)
+                            for i in range(1,len(articles)):
+                                #Send a button allowing them to read more of the article
+                                buttons = [
+                                                {
+                                                    "type":"postback",
+                                                    "title":"Read",
+                                                    "payload": i
+                                                }
+                                            ]
+                                #Send the title and summary of the article
+                                button_message(recipient_id,articles[i]['title'][0:350],buttons)
+                            
+                        else:
+                            send_message(recipient_id,'''I couldn't find anything on that, could you try making your search more specific? It would help if you asked a question! (Ex. "Who is the President of the Philippines?)''')
+                    return "Messaged Processed"
+                #If the person mistakenly just said search
+                elif string[0].lower() == 'search' and len(string) == 1:
+                    send_message(recipient_id, "Hi there! Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
+                    #TELL THEM THAT 
+                #All other cases 
+                else:
+                    answer = process_message(text)
+                    if answer:
+                        send_message(recipient_id,answer)
+                    else:
+                        send_message(recipient_id,"Can you say that again? Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
+                return "Messaged Processed"
+            #if user sends us a GIF, photo,video, or any other non-text item
+            if message['message'].get('attachments'):
+                #process_media(message['message'].get('attachments'))
+                pass
+                return "Messaged Processed"
+        #If user clicked one of the postback buttons
+        elif message.get('postback'):
+            print('DF Keys Existing: ',df.keys())
+            if message['postback'].get('title'):
+                #If user clicks the get started button
+                if message['postback']['title'] == 'Get Started':
+                    send_message(recipient_id, "Hey, I'm Dean! I allow Filipinos to access Google Search at no cost. This app runs purely on Free Facebook Data.\n\nIf you want to get started, just ask me a question! Make sure you write 'search' before your query. I'm excited to learn with you!\n\nI hope that you continue to stay safe! :)")
+                
+                #If user wants to read a specific article
+                #update df with new choice
+                elif df.get(recipient_id):
+                    #retrieve choice from postback
+                    choice = int(message['postback']['payload'])
+                    df[recipient_id][0] = choice
+                    if message['postback']['title'] == 'Read':
+                        print('DF Keys Read: ',df.keys())
+                        #dictionary for buttons
+                        buttons = [
+                                        {
+                                            "type":"postback",
+                                            "title":"Read more",
+                                            "payload":choice
+                                        }
+                                    ]
+                        #send button message
+                        if len(df[recipient_id][choice]['article']) == 1:
+                            send_message(recipient_id,df[recipient_id][choice]['article'][0])
+                            df[recipient_id][choice]['article'] = "End"
+                            with open('df.pickle', 'wb') as x:
+                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                            send_message(recipient_id,"End of Article")
+                        elif df[recipient_id][choice]['article'] == "End":
+                            send_message(recipient_id,"End of Article")
+                        else:
+                            button_message(recipient_id,df[recipient_id][choice]['article'][0],buttons)
+                            df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
+                            with open('df.pickle', 'wb') as x:
+                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                        return "Messaged Processed"
+                    #If user wants to read more of the article
+                    elif message['postback']['title'] == 'Read more':
+                        buttons = [
+                                        {
+                                            "type":"postback",
+                                            "title":"Read more",
+                                            "payload":choice
+                                        }
+                                    ]
+                        print('Read More Keys: ',df.keys())
+                        if len(df[recipient_id][choice]['article']) == 1:
+                            send_message(recipient_id, df[recipient_id][choice]['article'][0])
+                            df[recipient_id][choice]['article'] = "End"
+                            with open('df.pickle', 'wb') as x:
+                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                            send_message(recipient_id, "End of Article")
+                        elif df[recipient_id][choice]['article'] == "End":
+                            send_message(recipient_id, "End of Article")
+                        else:
+                            button_message(recipient_id, df[recipient_id][choice]['article'][0], buttons)
+                            df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
+                            with open('df.pickle', 'wb') as x:
+                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                        return "Messaged Processed"
+                    elif message['postback']['title'] == 'Feedback':
+                        pass
+                else:
+                    send_message(recipient_id, "Hi there! Could you please repeat your search? Make sure you write 'search' before your query. Ex. search Who is the President of the Philippines")
+                return "Messaged Processed"
+        else:
+            #gets triggered if there is another type of message that's not message/postback
+            pass
     return "Message processed"
 
-@timer
 def verify_fb_token(token_sent):
     #take token sent by facebook and verify it matches the verify token you sent
     #if they match, allow the request, else return an error 
@@ -226,20 +218,17 @@ def verify_fb_token(token_sent):
     return 'Invalid verification token'    
 
 #uses PyMessenger to send response to user
-@timer
 def send_message(recipient_id, response):
     '''sends user the text message provided via input response parameter'''
     bot.send_text_message(recipient_id, response)
     return "success"
 
 #uses PyMessenger to send message with button to user
-@timer
 def button_message(recipient_id,response,buttons):
     '''sends user the button message provided via input response parameter'''
     bot.send_button_message(recipient_id,response,buttons)
     return "success"
 
-@timer
 def feedback(recipient_id):
     '''Send a feedback button to let them provide feedback'''
     if random.random() <= 0.3:
@@ -254,5 +243,3 @@ def feedback(recipient_id):
                     ]
         button_message(recipient_id,message,buttons)
     return "success"
-
-

--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -21,8 +21,26 @@ df = {}
 message_dict = {}
 initial_message = {}
 
+def timer(func):
+    '''Print the Runtime of the decorated function'''
+    @functools.wraps(func)
+    def wrapper_timer(*args,**kwargs):
+        start_time = time.perf_counter()
+        value = func(*args,**kwargs)
+        end_time = time.perf_counter()
+        run_time = end_time - start_time
+        # print(f"Finished {func.__name__!r} in {run_time:.4f} secs")
+        # save time to test-time.txt
+        with open("test-time.txt", mode='a') as f:
+            print(f"Finished {func.__name__!r} in {run_time:.4f} secs", file=f)
+            print(len(df))
+
+        return value
+    return wrapper_timer
+
 #We will receive messages that Facebook sends our bot at this endpoint 
 @app.route("/", methods=['GET', 'POST'])
+@timer
 def receive_message():
     #remember list of articles and what are article the user is reading
     global df
@@ -35,169 +53,171 @@ def receive_message():
         token_sent = request.args.get("hub.verify_token")
 
         return verify_fb_token(token_sent)
+    
     #if the request was not get, it must be POST and we can just proceed with sending a message back to user
-    else:
-        if os.path.exists('df.pickle'):
-            with open('df.pickle', 'rb') as x:
-                df = pickle.load(x)
+    if os.path.exists('df.pickle'):
+        with open('df.pickle', 'rb') as x:
+            df = pickle.load(x)
 
-        with open('message.pickle', 'wb') as x:
-            pickle.dump(message_dict, x, protocol=pickle.HIGHEST_PROTOCOL)
+    with open('message.pickle', 'wb') as x:
+        pickle.dump(message_dict, x, protocol=pickle.HIGHEST_PROTOCOL)
 
-        # Get POST request sent to the bot
-        output = request.get_json()
-        print(output)
+    # Get POST request sent to the bot
+    output = request.get_json()
+    print(output)
 
-        # Get message details
-        message = output['entry'][0]['messaging'][0]
+    # Get message details
+    message = output['entry'][0]['messaging'][0]
 
-        #Facebook Messenger ID for user so we know where to send response back to
-        recipient_id = str(message['sender']['id'])
-        message_dict[recipient_id] = message
+    #Facebook Messenger ID for user so we know where to send response back to
+    recipient_id = str(message['sender']['id'])
+    message_dict[recipient_id] = message
 
-        #If user sent a message
-        if message.get('message'):
-            if message['message'].get('text'):
-                text = message['message'].get('text').strip()
-                string = text.lstrip().split(' ',1)
-                
-                #If the person wants to search something
-                if string[0].lower() == 'search' and len(string) >= 2:
+    #If user sent a message
+    if message.get('message'):
+        if message['message'].get('text'):
+            text = message['message'].get('text').strip()
+            string = text.lstrip().split(' ',1)
+            
+            #If the person wants to search something
+            if string[0].lower() == 'search' and len(string) >= 2:
 
-                    #Stops message spam
-                    with open('message.pickle', 'rb') as x:
-                        previous_message = pickle.load(x)
-                        check_message = previous_message
+                #Stops message spam
+                with open('message.pickle', 'rb') as x:
+                    previous_message = pickle.load(x)
+                    check_message = previous_message
 
-                    #Store recipient ID in previous message
-                    if check_message.get(recipient_id):
-                        pass
-                    else:
-                        initial_message[recipient_id] = {}
-                        previous_message = initial_message
-
-                    print('previous message: ', previous_message[recipient_id])
-                    print('message: ', message)
-                    if message == previous_message[recipient_id]:
-                        print('STOP FUNCTION BEFORE IT SPAMS')
-                        return 'message processed'
-                    else: 
-                        send_message(recipient_id,"Thank you for your search! Let me see what I can find. :)")
-                        articles = push(links(string[1]))
-                        if articles:
-                            df.pop(recipient_id, None)
-                            with open('df.pickle', 'wb') as x:
-                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                            articles.insert(0,1)
-                            df[recipient_id] = articles
-                            with open('df.pickle', 'wb') as z:
-                                pickle.dump(df, z, protocol = pickle.HIGHEST_PROTOCOL)
-                            #feedback(recipient_id)
-                            for i in range(1,len(articles)):
-                                #Send a button allowing them to read more of the article
-                                buttons = [
-                                                {
-                                                    "type":"postback",
-                                                    "title":"Read",
-                                                    "payload": i
-                                                }
-                                            ]
-                                #Send the title and summary of the article
-                                button_message(recipient_id,articles[i]['title'][0:350],buttons)
-                            
-                        else:
-                            send_message(recipient_id,'''I couldn't find anything on that, could you try making your search more specific? It would help if you asked a question! (Ex. "Who is the President of the Philippines?)''')
-                    return "Messaged Processed"
-                #If the person mistakenly just said search
-                elif string[0].lower() == 'search' and len(string) == 1:
-                    send_message(recipient_id, "Hi there! Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
-                    #TELL THEM THAT 
-                #All other cases 
+                #Store recipient ID in previous message
+                if check_message.get(recipient_id):
+                    pass
                 else:
-                    answer = process_message(text)
-                    if answer:
-                        send_message(recipient_id,answer)
+                    initial_message[recipient_id] = {}
+                    previous_message = initial_message
+
+                print('previous message: ', previous_message[recipient_id])
+                print('message: ', message)
+                if message == previous_message[recipient_id]:
+                    print('STOP FUNCTION BEFORE IT SPAMS')
+                    return 'message processed'
+                else: 
+                    send_message(recipient_id,"Thank you for your search! Let me see what I can find. :)")
+                    articles = push(links(string[1]))
+                    if articles:
+                        df.pop(recipient_id, None)
+                        with open('df.pickle', 'wb') as x:
+                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                        articles.insert(0,1)
+                        df[recipient_id] = articles
+                        with open('df.pickle', 'wb') as z:
+                            pickle.dump(df, z, protocol = pickle.HIGHEST_PROTOCOL)
+                        #feedback(recipient_id)
+                        for i in range(1,len(articles)):
+                            #Send a button allowing them to read more of the article
+                            buttons = [
+                                            {
+                                                "type":"postback",
+                                                "title":"Read",
+                                                "payload": i
+                                            }
+                                        ]
+                            #Send the title and summary of the article
+                            button_message(recipient_id,articles[i]['title'][0:350],buttons)
+                        
                     else:
-                        send_message(recipient_id,"Can you say that again? Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
+                        send_message(recipient_id,'''I couldn't find anything on that, could you try making your search more specific? It would help if you asked a question! (Ex. "Who is the President of the Philippines?)''')
                 return "Messaged Processed"
-            #if user sends us a GIF, photo,video, or any other non-text item
-            if message['message'].get('attachments'):
-                #process_media(message['message'].get('attachments'))
-                pass
-                return "Messaged Processed"
-        #If user clicked one of the postback buttons
-        elif message.get('postback'):
-            print('DF Keys Existing: ',df.keys())
-            if message['postback'].get('title'):
-                #If user clicks the get started button
-                if message['postback']['title'] == 'Get Started':
-                    send_message(recipient_id, "Hey, I'm Dean! I allow Filipinos to access Google Search at no cost. This app runs purely on Free Facebook Data.\n\nIf you want to get started, just ask me a question! Make sure you write 'search' before your query. I'm excited to learn with you!\n\nI hope that you continue to stay safe! :)")
-                
-                #If user wants to read a specific article
-                #update df with new choice
-                elif df.get(recipient_id):
-                    #retrieve choice from postback
-                    choice = int(message['postback']['payload'])
-                    df[recipient_id][0] = choice
-                    if message['postback']['title'] == 'Read':
-                        print('DF Keys Read: ',df.keys())
-                        #dictionary for buttons
-                        buttons = [
-                                        {
-                                            "type":"postback",
-                                            "title":"Read more",
-                                            "payload":choice
-                                        }
-                                    ]
-                        #send button message
-                        if len(df[recipient_id][choice]['article']) == 1:
-                            send_message(recipient_id,df[recipient_id][choice]['article'][0])
-                            df[recipient_id][choice]['article'] = "End"
-                            with open('df.pickle', 'wb') as x:
-                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                            send_message(recipient_id,"End of Article")
-                        elif df[recipient_id][choice]['article'] == "End":
-                            send_message(recipient_id,"End of Article")
-                        else:
-                            button_message(recipient_id,df[recipient_id][choice]['article'][0],buttons)
-                            df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
-                            with open('df.pickle', 'wb') as x:
-                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                        return "Messaged Processed"
-                    #If user wants to read more of the article
-                    elif message['postback']['title'] == 'Read more':
-                        buttons = [
-                                        {
-                                            "type":"postback",
-                                            "title":"Read more",
-                                            "payload":choice
-                                        }
-                                    ]
-                        print('Read More Keys: ',df.keys())
-                        if len(df[recipient_id][choice]['article']) == 1:
-                            send_message(recipient_id, df[recipient_id][choice]['article'][0])
-                            df[recipient_id][choice]['article'] = "End"
-                            with open('df.pickle', 'wb') as x:
-                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                            send_message(recipient_id, "End of Article")
-                        elif df[recipient_id][choice]['article'] == "End":
-                            send_message(recipient_id, "End of Article")
-                        else:
-                            button_message(recipient_id, df[recipient_id][choice]['article'][0], buttons)
-                            df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
-                            with open('df.pickle', 'wb') as x:
-                                pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
-                        return "Messaged Processed"
-                    elif message['postback']['title'] == 'Feedback':
-                        pass
+            #If the person mistakenly just said search
+            elif string[0].lower() == 'search' and len(string) == 1:
+                send_message(recipient_id, "Hi there! Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
+                #TELL THEM THAT 
+            #All other cases 
+            else:
+                answer = process_message(text)
+                if answer:
+                    send_message(recipient_id,answer)
                 else:
-                    send_message(recipient_id, "Hi there! Could you please repeat your search? Make sure you write 'search' before your query. Ex. search Who is the President of the Philippines")
-                return "Messaged Processed"
-        else:
-            #gets triggered if there is another type of message that's not message/postback
+                    send_message(recipient_id,"Can you say that again? Make sure that you type 'search' before your question. Ex. search Who is the President of the Philippines?")
+            return "Messaged Processed"
+        #if user sends us a GIF, photo,video, or any other non-text item
+        if message['message'].get('attachments'):
+            #process_media(message['message'].get('attachments'))
+            send_message(recipient_id, "I can only process text messages. I apologize for the inconvenience.")
             pass
+            return "Messaged Processed"
+    #If user clicked one of the postback buttons
+    elif message.get('postback'):
+        print('DF Keys Existing: ',df.keys())
+        if message['postback'].get('title'):
+            #If user clicks the get started button
+            if message['postback']['title'] == 'Get Started':
+                send_message(recipient_id, "Hey, I'm Dean! I allow Filipinos to access Google Search at no cost. This app runs purely on Free Facebook Data.\n\nIf you want to get started, just ask me a question! Make sure you write 'search' before your query. I'm excited to learn with you!\n\nI hope that you continue to stay safe! :)")
+            
+            #If user wants to read a specific article
+            #update df with new choice
+            elif df.get(recipient_id):
+                #retrieve choice from postback
+                choice = int(message['postback']['payload'])
+                df[recipient_id][0] = choice
+                if message['postback']['title'] == 'Read':
+                    print('DF Keys Read: ',df.keys())
+                    #dictionary for buttons
+                    buttons = [
+                                    {
+                                        "type":"postback",
+                                        "title":"Read more",
+                                        "payload":choice
+                                    }
+                                ]
+                    #send button message
+                    if len(df[recipient_id][choice]['article']) == 1:
+                        send_message(recipient_id,df[recipient_id][choice]['article'][0])
+                        df[recipient_id][choice]['article'] = "End"
+                        with open('df.pickle', 'wb') as x:
+                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                        send_message(recipient_id,"End of Article")
+                    elif df[recipient_id][choice]['article'] == "End":
+                        send_message(recipient_id,"End of Article")
+                    else:
+                        button_message(recipient_id,df[recipient_id][choice]['article'][0],buttons)
+                        df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
+                        with open('df.pickle', 'wb') as x:
+                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                    return "Messaged Processed"
+                #If user wants to read more of the article
+                elif message['postback']['title'] == 'Read more':
+                    buttons = [
+                                    {
+                                        "type":"postback",
+                                        "title":"Read more",
+                                        "payload":choice
+                                    }
+                                ]
+                    print('Read More Keys: ',df.keys())
+                    if len(df[recipient_id][choice]['article']) == 1:
+                        send_message(recipient_id, df[recipient_id][choice]['article'][0])
+                        df[recipient_id][choice]['article'] = "End"
+                        with open('df.pickle', 'wb') as x:
+                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                        send_message(recipient_id, "End of Article")
+                    elif df[recipient_id][choice]['article'] == "End":
+                        send_message(recipient_id, "End of Article")
+                    else:
+                        button_message(recipient_id, df[recipient_id][choice]['article'][0], buttons)
+                        df[recipient_id][choice]['article'] = df[recipient_id][choice]['article'][1:]
+                        with open('df.pickle', 'wb') as x:
+                            pickle.dump(df, x, protocol=pickle.HIGHEST_PROTOCOL)
+                    return "Messaged Processed"
+                elif message['postback']['title'] == 'Feedback':
+                    pass
+            else:
+                send_message(recipient_id, "Hi there! Could you please repeat your search? Make sure you write 'search' before your query. Ex. search Who is the President of the Philippines")
+            return "Messaged Processed"
+    else:
+        #gets triggered if there is another type of message that's not message/postback
+        pass
     return "Message processed"
 
+@timer
 def verify_fb_token(token_sent):
     #take token sent by facebook and verify it matches the verify token you sent
     #if they match, allow the request, else return an error 
@@ -206,17 +226,20 @@ def verify_fb_token(token_sent):
     return 'Invalid verification token'    
 
 #uses PyMessenger to send response to user
+@timer
 def send_message(recipient_id, response):
     '''sends user the text message provided via input response parameter'''
     bot.send_text_message(recipient_id, response)
     return "success"
 
 #uses PyMessenger to send message with button to user
+@timer
 def button_message(recipient_id,response,buttons):
     '''sends user the button message provided via input response parameter'''
     bot.send_button_message(recipient_id,response,buttons)
     return "success"
 
+@timer
 def feedback(recipient_id):
     '''Send a feedback button to let them provide feedback'''
     if random.random() <= 0.3:
@@ -232,14 +255,3 @@ def feedback(recipient_id):
         button_message(recipient_id,message,buttons)
     return "success"
 
-def timer(func):
-    '''Print the Runtime of the decorated function'''
-    @functools.wraps(func)
-    def wrapper_timer(*args,**kwargs):
-        start_time = time.perf_counter()
-        value = func(*args,**kwargs)
-        end_time = time.perf_counter()
-        run_time = end_time - start_time
-        print(f"Finished {func.__name__!r} in {run_time:.4f} secs")
-        return value
-    return wrapper_timer

--- a/chatbot/chatbot.py
+++ b/chatbot/chatbot.py
@@ -90,7 +90,7 @@ def receive_message():
 
                 #Store recipient ID in previous message
                 if check_message.get(recipient_id):
-                    pass            # Bryan: this could be cleaner. pass is unnecessary
+                    pass
                 else:
                     initial_message[recipient_id] = {}
                     previous_message = initial_message
@@ -254,8 +254,5 @@ def feedback(recipient_id):
                     ]
         button_message(recipient_id,message,buttons)
     return "success"
-
-def searchbot():
-    '''Search from Google based on recipient's message. Created for cleaner code and to record search time.'''
 
 


### PR DESCRIPTION
Past spam checker compares two dictionary variables, instead of the actual string of the messages. This doesn't actually prevent users to not spam messages. Fixed by only comparing the string of the messages.

When a spam occurs, DEAN now replies with a `You've repeated your previous message. DEAN hates spam!`.

Decorators (or wrapper functions) in Python can only be used if the decorator is above the function to be wrapped. Moved the `timer` function on top of all functions in `chatbot.py`.

(minimal) Added `.google-cookie` to `.gitignore`. It generates when I run the bot.

(First three commits was just me testing the app, all changes were made in the 4th commit)
